### PR TITLE
fix pyinstument overrides callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Markata Changelog
+
+## 0.1.0
+
+* fix: pyinstument plugin no longer overrides the main cli callback
+* feat: default is to run the profiler if pyinstrument is installed
+* fix: --profile is now under the build command
+
+### New cli help
+
+After the pyinstrument plugin was fixed --version and  --to-json are back, and --profile is now under the build command.
+
+![image](https://user-images.githubusercontent.com/22648375/150662983-547aebbd-c18c-4c17-8985-a6dc01cd29c7.png)
+
+
+## 0.0.1
+
+Initial Release 🎉
+

--- a/markata/plugins/base_cli.py
+++ b/markata/plugins/base_cli.py
@@ -71,6 +71,7 @@ def cli(app, markata):
             False,
             "--pdb",
         ),
+        profile: bool = False,
     ) -> None:
         import time
 
@@ -98,8 +99,14 @@ def cli(app, markata):
                         markata.run()
                     time.sleep(0.1)
 
+        if profile:
+            markata.should_profile_cli = True
+            markata.should_profile = True
+            markata.configure()
+
         if should_pdb:
             pdb_run(markata.run)
+
         else:
             markata.run()
 

--- a/markata/plugins/pyinstrument.py
+++ b/markata/plugins/pyinstrument.py
@@ -5,8 +5,6 @@ The profile will be saved to <output_dir>/_profile/index.html
 """
 from pathlib import Path
 
-import typer
-
 from markata import Markata
 from markata.hookspec import hook_impl, register_attr
 
@@ -20,26 +18,6 @@ except ModuleNotFoundError:
 class MarkataInstrument(Markata):
     should_profile = False
     profiler = None
-
-
-@hook_impl(tryfirst=True)
-def cli(app: typer.Typer, markata: MarkataInstrument) -> None:
-    def should_profile_callback(value: bool) -> None:
-        if value:
-            markata.should_profile_cli = True
-            markata.should_profile = True
-
-    @app.callback()
-    def should_profile(
-        version: bool = typer.Option(
-            None, "--profile", callback=should_profile_callback, is_eager=True
-        ),
-    ) -> None:
-        ...
-
-    @app.command()
-    def profile() -> None:
-        ...
 
 
 @hook_impl(tryfirst=True)
@@ -72,10 +50,12 @@ def save(markata: MarkataInstrument) -> None:
     "stop the profiler and save as late as possible"
     if markata.should_profile:
         try:
-            output_file = Path(markata.config["output_dir"]) / "_profile" / "index.html"
-            output_file.parent.mkdir(parents=True, exist_ok=True)
 
             if "profiler" in markata.__dict__.keys():
+                output_file = (
+                    Path(markata.config["output_dir"]) / "_profile" / "index.html"
+                )
+                output_file.parent.mkdir(parents=True, exist_ok=True)
                 markata.profiler.stop()
                 html = markata.profiler.output_html()
                 output_file.write_text(html)


### PR DESCRIPTION
resolves #5 

* fix: pyinstument plugin no longer overrides the main cli callback
* feat: default is to run the profiler if pyinstrument is installed
* fix: --profile is now under the build command

## New cli help

After the pyinstrument plugin was fixed --version and  --to-json are back, and --profile is now under the build command.

![image](https://user-images.githubusercontent.com/22648375/150662983-547aebbd-c18c-4c17-8985-a6dc01cd29c7.png)
