### PR TITLE
fixed invalid syntax in fstring

### DIFF
--- a/markata/plugins/feeds.py
+++ b/markata/plugins/feeds.py
@@ -68,8 +68,8 @@ def create_page(
         except BaseException as e:
             msg = textwrap.dedent(
                 f"""
-                    While processing {page =} markata hit the following exception
-                    during {filter =}
+                    While processing {page} markata hit the following exception
+                    during {filter}
                     {e}
                     """
             )


### PR DESCRIPTION
While trying to set up Markata got an exception and got converted into Invalid Syntax.

Did just I receive it and is it a valid syntax? I can be wrong here, I am using Python 3.7 

![image](https://user-images.githubusercontent.com/40317114/150977762-f6c55390-e893-436e-a9f3-fb65079b4d60.png)
