### PR TITLE
include the default_log_template in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include markata/plugins/default_post_template.html
+include markata/plugins/default_log_template.html


### PR DESCRIPTION
The default log template was not included in the package manifest, causing file not found errors.

https://github.com/WaylonWalker/waylonwalker.com/runs/6864299543?check_suite_focus=true

![image](https://user-images.githubusercontent.com/22648375/173427093-90ddca7b-4977-476f-b50b-1a3a99b9f3b2.png)
