### PR TITLE
feat: create nav from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * feat: add html logging with [setup_logging](/markata/plugins/setup_logging/)
   plugin is all new closes #37
 * fix: remove HTML tidy as the site generator tag
-* feat: create configurable navbar
+* feat: create configurable [navbar](https://markata.dev/nav)
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * feat: add html logging with [setup_logging](/markata/plugins/setup_logging/)
   plugin is all new closes #37
 * fix: remove HTML tidy as the site generator tag
+* feat: create configurable navbar
 
 ## 0.2.0
 

--- a/docs/nav.md
+++ b/docs/nav.md
@@ -1,0 +1,51 @@
+---
+title: Creating your Navbar
+description: Guide to creating a navbar in markata using the default template.
+
+---
+
+Creating navbar links with the default markata templates is done by adding
+links in your `markata.toml` configuration within a `markata.nav` block.
+
+## Example
+
+The following example will create two links, one to the root of the site, with
+the text `markata` and one to the github repo for markata with the text of
+`GitHub`.
+
+``` toml
+[markata.nav]
+'markata'='/'
+'GitHub'='https://github.com/WaylonWalker/markata'
+```
+### Result
+
+The resulting navbar would look something like this.
+
+---
+
+<nav>
+   <a href="/">
+    markata
+   </a>
+   <a href="https://github.com/WaylonWalker/markata">
+    GitHub
+   </a>
+</nav>
+
+---
+
+## In your own template
+
+If you want to continue using this method of maintaining your nav links with a
+custom template, add this block to your template where you want your nav to
+appear.
+
+``` html
+<nav>
+{% for text, link in config.get('nav', {}).items() %}
+    <a href='{{link}}'>{{text}}</a>
+{% endfor %}
+</nav>
+```
+

--- a/markata/plugins/default_post_template.html
+++ b/markata/plugins/default_post_template.html
@@ -421,10 +421,17 @@
   .slider.round:before {
   border-radius: 50%;
   }
+
   </style>
 </head>
-<body>
 
+  <nav>
+    {% for link, text in config.get('nav', {}).items() %}
+      <a href='{{link}}'>{{text}}</a>
+    {% endfor %}
+  </nav>
+
+<body>
   <div>
     <label id="theme-switch" class="theme-switch" for="checkbox-theme" title='light/dark mode toggle'>
       <input type="checkbox" id="checkbox-theme">

--- a/markata/plugins/default_post_template.html
+++ b/markata/plugins/default_post_template.html
@@ -426,7 +426,7 @@
 </head>
 
   <nav>
-    {% for link, text in config.get('nav', {}).items() %}
+    {% for text, link in config.get('nav', {}).items() %}
       <a href='{{link}}'>{{text}}</a>
     {% endfor %}
   </nav>


### PR DESCRIPTION
Creating navbar links with the default markata templates is done by adding
links in your `markata.toml` configuration within a `markata.nav` block.

## Example

The following example will create two links, one to the root of the site, with
the text `markata` and one to the github repo for markata with the text of
`GitHub`.

``` toml
[markata.nav]
'markata'='/'
'GitHub'='https://github.com/WaylonWalker/markata'
```
### Result

The resulting navbar would look something like this.

---

<nav>
   <a href="/">
    markata
   </a>
   <a href="https://github.com/WaylonWalker/markata">
    GitHub
   </a>
</nav>

---

## In your own template

If you want to continue using this method of maintaining your nav links with a
custom template, add this block to your template where you want your nav to
appear.

``` html
<nav>
{% for text, link in config.get('nav', {}).items() %}
    <a href='{{link}}'>{{text}}</a>
{% endfor %}
</nav>
```