### PR TITLE
RELEASE 0.3.0

### DIFF
--- a/.github/workflows/release-markata.yml
+++ b/.github/workflows/release-markata.yml
@@ -23,15 +23,17 @@ jobs:
       - run: flake8 markata
       - run: pytest
 
-      - run: pip install bump2version && bump2version pre
-        if: github.ref == 'refs/heads/develop'
-
-      - name: Commit report
+      - name: automatically pre-release develop branch
         run: |
           git config --global user.name 'autobump'
           git config --global user.email 'autobump@markata.dev'
+          pip install bump2version
+          bump2version pre
           git push
           git push --tags
+        if: github.ref == 'refs/heads/develop'
+
+      - name: Commit report
 
       - name: build
         run: |

--- a/.github/workflows/release-markata.yml
+++ b/.github/workflows/release-markata.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: install markata
         run: pip install -e ".[dev]"
@@ -30,6 +30,16 @@ jobs:
           git config --global user.email 'autobump@markata.dev'
           pip install bump2version
           bump2version pre
+          git push
+          git push --tags
+
+      - name: automatically pre-release develop branch
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config --global user.name 'autobump'
+          git config --global user.email 'autobump@markata.dev'
+          pip install bump2version
+          bump2version minor
           git push
           git push --tags
 

--- a/.github/workflows/release-markata.yml
+++ b/.github/workflows/release-markata.yml
@@ -23,19 +23,30 @@ jobs:
       - run: flake8 markata
       - run: pytest
 
+      - run: pip install bump2version && bump2version pre
+        if: github.ref == 'refs/heads/develop'
+
+      - name: Commit report
+        run: |
+          git config --global user.name 'autobump'
+          git config --global user.email 'autobump@markata.dev'
+          git push
+          git push --tags
+
       - name: build
         run: |
           pip install wheel
           python setup.py sdist bdist_wheel
+
+
+      - name: pypi-publish-pre
+        if: github.ref == 'refs/heads/develop'
+        uses: pypa/gh-action-pypi-publish@v1.1.0
+        with:
+          password: ${{ secrets.pypi_password }}
+
       - name: pypi-publish
         if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
-          # PyPI user
-          # Password for your PyPI user or an access token
           password: ${{ secrets.pypi_password }}
-          # The repository URL to use
-          # repository_url: # optional
-          # The target directory for distribution
-          # packages_dir: # optional, default is dist
-

--- a/.github/workflows/release-markata.yml
+++ b/.github/workflows/release-markata.yml
@@ -24,6 +24,7 @@ jobs:
       - run: pytest
 
       - name: automatically pre-release develop branch
+        if: github.ref == 'refs/heads/develop'
         run: |
           git config --global user.name 'autobump'
           git config --global user.email 'autobump@markata.dev'
@@ -31,9 +32,6 @@ jobs:
           bump2version pre
           git push
           git push --tags
-        if: github.ref == 'refs/heads/develop'
-
-      - name: Commit report
 
       - name: build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * fix: remove HTML tidy as the site generator tag
 * feat: create configurable [navbar](https://markata.dev/nav)
 * perf: prevent double runs on pre-render and post-render #39
+* perf: prevent duplicate ruun from to_dict calling pre-render #53
+   * `to_dict` only runs up to `render` phase if necessary as directed by `register_attr`
 * fix: pyinstrument will not create a second profiler causing it to end in errors #50
 
 ### Double Runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
    * `to_dict` only runs up to `render` phase if necessary as directed by `register_attr`
 * perf: only prettify if configured #54
 * fix: pyinstrument will not create a second profiler causing it to end in errors #50
+* fix: sites without feeds config do not create an index #55
 
 ### Double Runs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * perf: prevent double runs on pre-render and post-render #39
 * perf: prevent duplicate ruun from to_dict calling pre-render #53
    * `to_dict` only runs up to `render` phase if necessary as directed by `register_attr`
+* perf: only prettify if configured #54
 * fix: pyinstrument will not create a second profiler causing it to end in errors #50
 
 ### Double Runs
@@ -22,6 +23,18 @@ with your plugins not running before asking for attributes created by your
 plugin make sure that you implement the
 [@register_attr](https://markata.dev/markata/hookspec/#register_attr-function)
 decorator.
+
+### Prettify
+
+prettify html has been turned off by default as beautifulsoup4 prettify was
+taking a significant time, and was often popping up as the slowest parts in my
+personal `_profile`.  If you want to continue running prettify throughout the
+build you can set a flag in your config to continue running prettify.
+
+``` toml
+[markata]
+prettify_html = true
+```
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
   plugin is all new closes #37
 * fix: remove HTML tidy as the site generator tag
 * feat: create configurable [navbar](https://markata.dev/nav)
+* perf: prevent double runs on pre-render and post-render #39
+
+### Double Runs
+
+Previously markata would catch AttributeError and run the previous step any
+time you ran a step too early.  The way this was implemented caused some steps
+such as pre-render and post-render to run twice with every single run.
+
+This change will no longer catch attribute errors. If you run into any issues
+with your plugins not running before asking for attributes created by your
+plugin make sure that you implement the
+[@register_attr](https://markata.dev/markata/hookspec/#register_attr-function)
+decorator.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,32 @@
 # Markata Changelog
 
+## dev
+
+* feat: add html logging with [setup_logging](/markata/plugins/setup_logging/)
+  plugin is all new closes #37
+
 ## 0.2.0
 
-* feat: [auto_description](/markata/plugins/auto_description/) plugin is all new closes #13
+* feat: [auto_description](/markata/plugins/auto_description/) plugin is all
+  new closes #13
 * deprecated: long_description has been deprecated by auto_description
-* fix: [covers](/markata/plugins/covers/) plugin which would previously skip every time.
-* feat: [`markata clean`](/markata/plugins/base_cli/#clean-function) cleans up your cache and output from the command line
-* fix: [`publish_source`](/markata/plugins/publish_source/) plugin will now ignore any non yaml serializable values 
+* fix: [covers](/markata/plugins/covers/) plugin which would previously skip
+  every time.
+* feat: [`markata clean`](/markata/plugins/base_cli/#clean-function) cleans up
+  your cache and output from the command line
+* fix: [`publish_source`](/markata/plugins/publish_source/) plugin will now
+  ignore any non yaml serializable values 
 * feat: Default template colors are now customizable
 * feat: Default template now has light and dark theme
 * feat: map now has the ability to map entire posts
-* feat: [prevnext](/markata/plugins/prevnext/) plugin was added to link between posts closes #20
-* feat: [jinja_md](/markata/plugins/jinja_md/) plugins was added to incorporate jinja into all the markdown
-* breaking: [feeds](/markata/plugins/feeds) config now has feeds and feeds_config
-* feat: `output_html` can now be specified in the frontmatter [see example](/markata/plugins/publish_html/#explicityly-set-the-output)
+* feat: [prevnext](/markata/plugins/prevnext/) plugin was added to link between
+  posts closes #20
+* feat: [jinja_md](/markata/plugins/jinja_md/) plugins was added to incorporate
+  jinja into all the markdown
+* breaking: [feeds](/markata/plugins/feeds) config now has feeds and
+  feeds_config
+* feat: `output_html` can now be specified in the frontmatter [see
+  example](/markata/plugins/publish_html/#explicityly-set-the-output)
 * feat: edit link is now included in the default page template closes #21
 
 ### breaking change to feeds config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * feat: add html logging with [setup_logging](/markata/plugins/setup_logging/)
   plugin is all new closes #37
 * fix: remove HTML tidy as the site generator tag
+* feat: create configurable [navbar](https://markata.dev/nav)
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * feat: add html logging with [setup_logging](/markata/plugins/setup_logging/)
   plugin is all new closes #37
+* fix: remove HTML tidy as the site generator tag
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * fix: remove HTML tidy as the site generator tag
 * feat: create configurable [navbar](https://markata.dev/nav)
 * perf: prevent double runs on pre-render and post-render #39
+* fix: pyinstrument will not create a second profiler causing it to end in errors #50
 
 ### Double Runs
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include markata/plugins/default_post_template.html
+include markata/plugins/default_log_template.html

--- a/docs/nav.md
+++ b/docs/nav.md
@@ -1,0 +1,51 @@
+---
+title: Creating your Navbar
+description: Guide to creating a navbar in markata using the default template.
+
+---
+
+Creating navbar links with the default markata templates is done by adding
+links in your `markata.toml` configuration within a `markata.nav` block.
+
+## Example
+
+The following example will create two links, one to the root of the site, with
+the text `markata` and one to the github repo for markata with the text of
+`GitHub`.
+
+``` toml
+[markata.nav]
+'markata'='/'
+'GitHub'='https://github.com/WaylonWalker/markata'
+```
+### Result
+
+The resulting navbar would look something like this.
+
+---
+
+<nav>
+   <a href="/">
+    markata
+   </a>
+   <a href="https://github.com/WaylonWalker/markata">
+    GitHub
+   </a>
+</nav>
+
+---
+
+## In your own template
+
+If you want to continue using this method of maintaining your nav links with a
+custom template, add this block to your template where you want your nav to
+appear.
+
+``` html
+<nav>
+{% for text, link in config.get('nav', {}).items() %}
+    <a href='{{link}}'>{{text}}</a>
+{% endfor %}
+</nav>
+```
+

--- a/markata.toml
+++ b/markata.toml
@@ -7,6 +7,10 @@
 #
 #                                                  markata.dev
 
+[markata.nav]
+'markata'='/'
+'GitHub'='https://github.com/WaylonWalker/markata'
+
 [markata]
 # bump site version to bust GitHub actions cache
 site_version = 13
@@ -60,9 +64,9 @@ twitter_site = "@_waylonwalker"
 [markata.feeds_config]
 
 [markata.feeds.docs]
-filter='"markata" not in slug and "tests" not in slug'
+filter='"markata" not in slug and "tests" not in slug and "404" not in slug'
 sort='slug'
-card_template="<li class='post'><a href='/{{ slug }}/'>{{ slug }}</a></li>"
+card_template="<li class='post'><a href='/{{ slug }}/'>{{ slug }}<p style='color: white; text-decoration: none;'>{{ description }}</p></a> </li>"
 
 [markata.feeds.autodoc]
 title="All Markata Modules"

--- a/markata.toml
+++ b/markata.toml
@@ -66,22 +66,22 @@ twitter_site = "@_waylonwalker"
 [markata.feeds.docs]
 filter='"markata" not in slug and "tests" not in slug and "404" not in slug'
 sort='slug'
-card_template="<li class='post'><a href='/{{ slug }}/'>{{ slug }}<p style='color: white; text-decoration: none;'>{{ description }}</p></a> </li>"
+card_template="<li class='post'><a href='/{{ slug }}/'>{{ title }}<p style='color: white; text-decoration: none;'>{{ description }}</p></a> </li>"
 
 [markata.feeds.autodoc]
 title="All Markata Modules"
 filter="True"
-card_template="<li class='post'><a href='/{{ slug }}/'>{{ slug }}</a></li>"
+card_template="<li class='post'><a href='/{{ slug }}/'>{{ title }}</a></li>"
 
 [markata.feeds.core_modules]
 title="Markata Core Modules"
 filter="'plugin' not in slug"
-card_template="<li class='post'><a href='/{{ slug }}/'>{{ slug }}</a></li>"
+card_template="<li class='post'><a href='/{{ slug }}/'>{{ title }}</a></li>"
 
 [markata.feeds.plugins]
 title="Markata Plugins"
 filter="'plugin' in slug"
-card_template="<li class='post'><a href='/{{ slug }}/'>{{ slug }}</a></li>"
+card_template="<li class='post'><a href='/{{ slug }}/'>{{ title }}</a></li>"
 
 [markata.jinja_md]
 ignore=[

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -28,7 +28,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.2.0"
+__version__ = "0.3.0.b0"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -29,7 +29,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.3.0.b7"
+__version__ = "0.3.0.b8"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -315,7 +315,6 @@ class Markata:
         return {"config": self.config, "articles": [a.to_dict() for a in self.articles]}
 
     def to_dict(self) -> dict:
-        self.render()
         return self._to_dict()
 
     def to_json(self) -> str:

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -29,7 +29,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.3.0.b6"
+__version__ = "0.3.0.b7"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -28,7 +28,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.3.0.b1"
+__version__ = "0.3.0.b2"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -258,7 +258,11 @@ class Markata:
         return config
 
     def get_config(
-        self, key: str, warn: bool = True, suggested: Optional[str] = None
+        self,
+        key: str,
+        default: str = "",
+        warn: bool = True,
+        suggested: Optional[str] = None,
     ) -> Any:
         if key in self.config.keys():
             return self.config[key]
@@ -267,15 +271,15 @@ class Markata:
             if suggested is None:
                 suggested = textwrap.dedent(
                     f"""
-                        \[markata]
-                        {key} = value
-                    """  # noqa: W605
+                    [markata]
+                    {key} = '{default}'
+                    """
                 )
             if warn:
-                self.console.log(
+                logger.warning(
                     textwrap.dedent(
                         f"""
-                        Warning site_name is not set in markata config, sitemap will
+                        Warning {key} is not set in markata config, sitemap will
                         be missing root site_name
                         to resolve this open your markata.toml and add
 
@@ -283,8 +287,8 @@ class Markata:
 
                         """
                     ),
-                    style="yellow",
                 )
+        return default
 
     def make_hash(self, *keys: str) -> str:
         str_keys = [str(key) for key in keys]

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import datetime
 import hashlib
 import importlib
+import logging
 import os
 import sys
 import textwrap
@@ -31,6 +32,8 @@ from markata.lifecycle import LifeCycle
 
 __version__ = "0.3.0.b8"
 
+
+logger = logging.getLogger("markata")
 
 DEFAULT_MD_EXTENSIONS = [
     "codehilite",

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -29,7 +29,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.3.0.b3"
+__version__ = "0.3.0.b4"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -29,7 +29,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.3.0.b5"
+__version__ = "0.3.0.b6"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -78,6 +78,7 @@ DEFAULT_HOOKS = [
     "markata.plugins.base_cli",
     "markata.plugins.tui",
     "markata.plugins.jinja_md",
+    "markata.plugins.setup_logging",
 ]
 
 DEFUALT_CONFIG = {

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -10,6 +10,7 @@ import os
 import sys
 import textwrap
 from datetime import timedelta
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
@@ -382,6 +383,7 @@ class Markata:
 
         return [a for a in self.articles if evalr(a)]
 
+    @lru_cache
     def map(
         self,
         func: str = "title",

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -29,7 +29,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.3.0.b4"
+__version__ = "0.3.0.b5"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -123,16 +123,24 @@ class Markata:
         return FanoutCache(self.MARKATA_CACHE_DIR, statistics=True)
 
     def __getattr__(self, item: str) -> Any:
+        if item in self._pm.hook.__dict__.keys():
+            # item is a hook, return a callable function
+            return lambda: self.run(item)
+
         if item in self.__dict__.keys():
+            # item is an attribute, return it
             return self.__getitem__(item)
+
         elif item in self.registered_attrs.keys():
+            # item is created by a plugin, run it
             stage_to_run_to = max(
                 [attr["lifecycle"] for attr in self.registered_attrs[item]]
             ).name
             self.run(stage_to_run_to)
             return getattr(self, item)
         else:
-            raise AttributeError(item)
+            # Markata does not know what this is, raise
+            raise AttributeError(f"'Markata' object has no attribute '{item}'")
 
     @property
     def server(self) -> Server:
@@ -306,11 +314,8 @@ class Markata:
         return {"config": self.config, "articles": [a.to_dict() for a in self.articles]}
 
     def to_dict(self) -> dict:
-        try:
-            return self._to_dict()
-        except AttributeError:
-            self.render()
-            return self._to_dict()
+        self.render()
+        return self._to_dict()
 
     def to_json(self) -> str:
         import json
@@ -344,64 +349,6 @@ class Markata:
         )
         return articles
 
-    @set_phase
-    def glob(self) -> Markata:
-        """run glob hooks
-
-        Glob hooks should append file lists to the markata object for later
-        hooks to build from.  The default loader will utilize the `files`
-        attribute for loading.
-        """
-
-        try:
-            self._pm.hook.glob(markata=self)
-        except AttributeError:
-            self.configure()
-            self._pm.hook.glob(markata=self)
-
-        return self
-
-    @set_phase
-    def load(self) -> Markata:
-        try:
-            self._pm.hook.load(markata=self)
-        except AttributeError:
-            self.glob()
-            self._pm.hook.load(markata=self)
-        return self
-
-    # @set_phase
-    def pre_render(self) -> Markata:
-        self._pm.hook.pre_render(markata=self)
-        return self
-
-    # @set_phase
-    def render(self) -> Markata:
-        try:
-            self._pm.hook.pre_render(markata=self)
-            self._pm.hook.render(markata=self)
-            self._pm.hook.post_render(markata=self)
-        except AttributeError:
-            self.load()
-            self._pm.hook.pre_render(markata=self)
-            self._pm.hook.render(markata=self)
-            self._pm.hook.post_render(markata=self)
-        return self
-
-    # @set_phase
-    def post_render(self) -> Markata:
-        self._pm.hook.post_render(markata=self)
-        return self
-
-    # @set_phase
-    def save(self) -> Markata:
-        try:
-            self._pm.hook.save(markata=self)
-        except AttributeError:
-            self.render()
-            self._pm.hook.save(markata=self)
-        return self
-
     def run(self, lifecycle: LifeCycle = None) -> Markata:
         if lifecycle is None:
             lifecycle = getattr(LifeCycle, max(LifeCycle._member_map_))
@@ -414,7 +361,7 @@ class Markata:
         self.console.log(f"running {stages_to_run}")
         for stage in stages_to_run:
             self.console.log(f"{stage} running")
-            getattr(self, stage)()
+            getattr(self._pm.hook, stage)(markata=self)
             self.console.log(f"{stage} complete")
 
         with self.cache as cache:

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -28,7 +28,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.3.0.b0"
+__version__ = "0.3.0.b1"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -28,7 +28,7 @@ from markata.cli.server import Server
 from markata.cli.summary import Summary
 from markata.lifecycle import LifeCycle
 
-__version__ = "0.3.0.b2"
+__version__ = "0.3.0.b3"
 
 
 DEFAULT_MD_EXTENSIONS = [

--- a/markata/plugins/default_log_template.html
+++ b/markata/plugins/default_log_template.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="generator" content="HTML Tidy for HTML5 for Linux version 5.2.0">
+  <title>{{ title }}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script>
+    function setTheme(theme) {
+        document.documentElement.setAttribute("data-theme", theme);
+    }
+
+    function detectColorSchemeOnLoad() {
+        //local storage is used to override OS theme settings
+        if (localStorage.getItem("theme")) {
+            if (localStorage.getItem("theme") == "dark") {
+                setTheme('dark')
+            } else if (localStorage.getItem("theme") == "light") {
+                setTheme('light')
+            }
+        } else if (!window.matchMedia) {
+            //matchMedia method not supported
+            setTheme('light')
+            return false;
+        } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+            //OS theme setting detected as dark
+            setTheme('dark')
+        } else {
+            setTheme('light')
+        }
+    }
+    detectColorSchemeOnLoad();
+    document.addEventListener('DOMContentLoaded', function() {
+        //identify the toggle switch HTML element
+        const toggleSwitch = document.querySelector('#theme-switch input[type="checkbox"]');
+
+        //function that changes the theme, and sets a localStorage variable to track the theme between page loads
+        function switchTheme(e) {
+            if (e.target.checked) {
+                localStorage.setItem('theme', 'dark');
+                document.documentElement.setAttribute('data-theme', 'dark');
+                toggleSwitch.checked = true;
+            } else {
+                localStorage.setItem('theme', 'light');
+                document.documentElement.setAttribute('data-theme', 'light');
+                toggleSwitch.checked = false;
+            }
+        }
+
+        //listener for changing themes
+        toggleSwitch.addEventListener('change', switchTheme, false);
+
+        //pre-check the dark-theme checkbox if dark-theme is set
+        if (document.documentElement.getAttribute("data-theme") == "dark") {
+            toggleSwitch.checked = true;
+        }
+
+    }, false);
+  </script>
+  <style>
+      :root {
+        --color-bg: {{ config.get('color_bg', '#1f2022') }};
+        --color-bg-code: {{ config.get('color_bg_code', '#1f2022') }};
+        --color-text: {{ config.get('color_text', '#eefbfe') }};
+        --color-link: {{ config.get('color_link', '#fb30c4') }}; 
+        --color-accent: {{ config.get('color_accent', '#e1bd00c9') }};
+        --overlay-brightness: {{ config.get('overlay_brightness', '.85') }};
+        --body-width: {{ config.get('body_width', '800px') }};
+      }
+      [data-theme="dark"] {
+        --color-bg: {{ config.get('color_bg', '#1f2022') }};
+        --color-bg-code: {{ config.get('color_bg_code', '#1f2022') }};
+        --color-text: {{ config.get('color_text', '#eefbfe') }};
+        --color-link: {{ config.get('color_link', '#fb30c4') }}; 
+        --color-accent: {{ config.get('color_accent', '#e1bd00c9') }};
+        --overlay-brightness: {{ config.get('overlay_brightness', '.85') }};
+        --body-width: {{ config.get('body_width', '800px') }};
+      }
+      [data-theme="light"] {
+        --color-bg: {{ config.get('color_bg_light', '#eefbfe') }};
+        --color-bg-code: {{ config.get('color_bg_code_light', '#eefbfe') }};
+        --color-text: {{ config.get('color_text_light', '#1f2022') }};
+        --color-link: {{ config.get('color_link_light', '#fb30c4') }}; 
+        --color-accent: {{ config.get('color_accent_light', '#ffeb00') }};
+        --overlay-brightness: {{ config.get('overlay_brightness_light', '.95') }};
+      }
+
+      html  { 
+        font-family: "Space Mono", monospace;
+        background: var(--color-bg);
+        color: var(--color-text);
+      }
+      a { 
+        color: var(--color-link);
+      }
+      .heading-permalink {
+        font-size: .7em;
+      }
+      body {
+        max-width: var(--body-width);
+        margin: 5rem auto;
+        padding: 0 .5rem;
+        font-size: 1rem;
+        line-height: 1.56;
+      }
+      blockquote {
+        background: var(--color-bg);
+        filter: brightness(var(--overlay-brightness));
+        border-left: 5px solid var(--color-accent);
+        padding-left: 1rem;
+        margin: 1rem;
+        }
+      li.post {
+        list-style-type: None;
+        padding: .2rem 0;
+      }
+      pre {
+        padding: 1rem;
+        max-width: fit-content;
+        overflow-x: auto;
+      }
+
+
+      .highlight  {
+        background: var(--color-bg-code);
+        color: var(--color-text);
+        filter: brightness(var(--overlay-brightness));
+      }
+      .highlight .c { color: #8b8b8b } /* Comment */
+      .highlight .err { color: #960050; background-color: #1e0010 } /* Error */
+      .highlight .k { color: #c678dd } /* Keyword */
+      .highlight .l { color: #ae81ff } /* Literal */
+      .highlight .n { color: #abb2bf } /* Name */
+      .highlight .o { color: #c678dd } /* Operator */
+      .highlight .p { color: #abb2bf } /* Punctuation */
+      .highlight .ch { color: #8b8b8b } /* Comment.Hashbang */
+      .highlight .cm { color: #8b8b8b } /* Comment.Multiline */
+      .highlight .cp { color: #8b8b8b } /* Comment.Preproc */
+      .highlight .cpf { color: #8b8b8b } /* Comment.PreprocFile */
+      .highlight .c1 { color: #8b8b8b } /* Comment.Single */
+      .highlight .cs { color: #8b8b8b } /* Comment.Special */
+      .highlight .gd { color: #c678dd } /* Generic.Deleted */
+      .highlight .ge { font-style: italic } /* Generic.Emph */
+      .highlight .gi { color: #a6e22e } /* Generic.Inserted */
+      .highlight .gs { font-weight: bold } /* Generic.Strong */
+      .highlight .gu { color: #8b8b8b } /* Generic.Subheading */
+      .highlight .kc { color: #c678dd } /* Keyword.Constant */
+      .highlight .kd { color: #c678dd } /* Keyword.Declaration */
+      .highlight .kn { color: #c678dd } /* Keyword.Namespace */
+      .highlight .kp { color: #c678dd } /* Keyword.Pseudo */
+      .highlight .kr { color: #c678dd } /* Keyword.Reserved */
+      .highlight .kt { color: #c678dd } /* Keyword.Type */
+      .highlight .ld { color: #e6db74 } /* Literal.Date */
+      .highlight .m { color: #ae81ff } /* Literal.Number */
+      .highlight .s { color: #e6db74 } /* Literal.String */
+      .highlight .na { color: #a6e22e } /* Name.Attribute */
+      .highlight .nb { color: #98c379 } /* Name.Builtin */
+      .highlight .nc { color: #abb2bf } /* Name.Class */
+      .highlight .no { color: #c678dd } /* Name.Constant */
+      .highlight .nd { color: #abb2bf } /* Name.Decorator */
+      .highlight .ni { color: #abb2bf } /* Name.Entity */
+      .highlight .ne { color: #a6e22e } /* Name.Exception */
+      .highlight .nf { color: #61afef } /* Name.Function */
+      .highlight .nl { color: #abb2bf } /* Name.Label */
+      .highlight .nn { color: #abb2bf } /* Name.Namespace */
+      .highlight .nx { color: #a6e22e } /* Name.Other */
+      .highlight .py { color: #abb2bf } /* Name.Property */
+      .highlight .nt { color: #c678dd } /* Name.Tag */
+      .highlight .nv { color: #abb2bf } /* Name.Variable */
+      .highlight .ow { color: #c678dd } /* Operator.Word */
+      .highlight .w { color: #abb2bf } /* Text.Whitespace */
+      .highlight .mb { color: #ae81ff } /* Literal.Number.Bin */
+      .highlight .mf { color: #ae81ff } /* Literal.Number.Float */
+      .highlight .mh { color: #ae81ff } /* Literal.Number.Hex */
+      .highlight .mi { color: #ae81ff } /* Literal.Number.Integer */
+      .highlight .mo { color: #ae81ff } /* Literal.Number.Oct */
+      .highlight .sa { color: #e6db74 } /* Literal.String.Affix */
+      .highlight .sb { color: #e6db74 } /* Literal.String.Backtick */
+      .highlight .sc { color: #e6db74 } /* Literal.String.Char */
+      .highlight .dl { color: #e6db74 } /* Literal.String.Delimiter */
+      .highlight .sd { color: #98c379 } /* Literal.String.Doc */
+      .highlight .s2 { color: #98c379 } /* Literal.String.Double */
+      .highlight .se { color: #ae81ff } /* Literal.String.Escape */
+      .highlight .sh { color: #e6db74 } /* Literal.String.Heredoc */
+      .highlight .si { color: #e6db74 } /* Literal.String.Interpol */
+      .highlight .sx { color: #e6db74 } /* Literal.String.Other */
+      .highlight .sr { color: #e6db74 } /* Literal.String.Regex */
+      .highlight .s1 { color: #e6db74 } /* Literal.String.Single */
+      .highlight .ss { color: #e6db74 } /* Literal.String.Symbol */
+      .highlight .bp { color: #abb2bf } /* Name.Builtin.Pseudo */
+      .highlight .fm { color: #61afef } /* Name.Function.Magic */
+      .highlight .vc { color: #abb2bf } /* Name.Variable.Class */
+      .highlight .vg { color: #abb2bf } /* Name.Variable.Global */
+      .highlight .vi { color: #abb2bf } /* Name.Variable.Instance */
+      .highlight .vm { color: #abb2bf } /* Name.Variable.Magic */
+      .highlight .il { color: #ae81ff } /* Literal.Number.Integer.Long */
+
+  /* Tab style starts here */
+  .tabbed-set {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  margin: 1em 0;
+  border-radius: 0.1rem;
+  }
+
+  .tabbed-set > input {
+  display: none;
+  }
+
+  .tabbed-set label {
+  width: auto;
+  padding: 0.9375em 1.25em 0.78125em;
+  font-weight: 700;
+  font-size: 0.84em;
+  white-space: nowrap;
+  border-bottom: 0.15rem solid transparent;
+  border-top-left-radius: 0.1rem;
+  border-top-right-radius: 0.1rem;
+  cursor: pointer;
+  transition: background-color 250ms, color 250ms;
+  }
+
+  .tabbed-set .tabbed-content {
+  width: 100%;
+  display: none;
+  box-shadow: 0 -.05rem #ddd;
+  }
+
+  .tabbed-set input {
+  position: absolute;
+  opacity: 0;
+  }
+
+  /* fonts */
+  h1 {
+    font-weight: 700;
+  }
+
+  h1#title a {
+    font-size: 16px;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-top: 3rem;
+  }
+
+  h1 {
+    font-size: 2.5em;
+    margin-top: 5rem;
+  }
+
+  h2 {
+    font-size: 1.63rem;
+    margin-top: 5rem;
+  }
+
+
+
+  p {
+    font-size: 21px;
+    font-style: normal;
+    font-variant: normal;
+    font-weight: 400;
+    line-height: 1.5;
+  }
+
+  @media only screen and (max-width: 700px) {
+    p {
+        font-size: 18px;
+    }
+  }
+
+  @media only screen and (max-width: 600px) {
+    p {
+        font-size: 16px;
+    }
+  }
+
+  @media only screen and (max-width: 500px) {
+    p {
+        font-size: 14px;
+    }
+  }
+
+  @media only screen and (max-width: 400px) {
+    p {
+        font-size: 12px;
+    }
+  }
+
+
+  pre {
+    font-style: normal;
+    font-variant: normal;
+    font-weight: 400;
+    line-height: 18.5714px; */
+  }
+
+  a {
+    font-weight: 600;
+    text-decoration-color: var(--color-accent);
+    color: var(--color-link);
+    padding: .3rem .5rem;
+    display: inline-block;
+  }
+
+  .admonition {
+    padding: 15px;
+    margin-bottom: 20px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    text-align: left;
+  }
+
+  .admonition.note {
+    color: #79d3e6;
+    background-color: #123c52;
+    border-color: #1c7183;
+  }
+
+  .admonition.warning {
+    color: #e6ca7a;
+    background-color: #4f4409;
+    border-color: #855c0d;
+  }
+
+  .admonition.danger {
+    color: #e67471;
+    background-color: #461c1c;
+    border-color: #6e2b33;
+  }
+
+  .admonition-title {
+    font-weight: bold;
+    text-align: left;
+  }
+
+  table {
+    margin: 1rem 0;
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: block;
+    max-width: -moz-fit-content;
+    max-width: fit-content;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+  table thead th {
+    border: solid 1px var(--color-text);
+    padding: 10px;
+    text-align: left;
+  }
+
+  table tbody td {
+    border: solid 1px var(--color-text);
+    padding: 10px;
+  }
+  .theme-switch {
+  z-index: 10;
+  display: inline-block;
+  height: 34px;
+  position: relative;
+  width: 60px;
+
+    display: flex;
+    justify-content: flex-end;
+    margin-right: 1rem;
+    margin-left: auto;
+    position: fixed;
+    right: 1rem;
+    top: 1rem;
+  }
+
+  .theme-switch input {
+  display:none;
+
+  }
+
+  .slider {
+  background-color: #ccc;
+  bottom: 0;
+  cursor: pointer;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: .4s;
+  }
+
+  .slider:before {
+  background-color: #fff;
+  bottom: 4px;
+  content: "";
+  height: 26px;
+  left: 4px;
+  position: absolute;
+  transition: .4s;
+  width: 26px;
+  }
+
+  input:checked + .slider {
+  background-color: #343434;
+  }
+  input:checked + .slider:before {
+  background-color: #848484;
+  }
+
+  input:checked + .slider:before {
+  transform: translateX(26px);
+  }
+
+  .slider.round {
+  border-radius: 34px;
+  }
+
+  .slider.round:before {
+  border-radius: 50%;
+  }
+
+li {
+  list-style-type: none;
+}
+.time {
+  color: var(--color-link);
+}
+
+.name {
+  color: var(--color-accent);
+}
+.INFO {
+  color: #728ffa;
+}
+
+
+.WARNING {
+  color: salmon;
+}
+p.message {
+  padding-left: 1rem;
+  border-left: 1px solid #848484;
+
+}
+  </style>
+</head>
+<body>
+
+  <div>
+    <label id="theme-switch" class="theme-switch" for="checkbox-theme" title='light/dark mode toggle'>
+      <input type="checkbox" id="checkbox-theme">
+      <div class="slider round"> </div>
+    </label>
+  </div>
+  <section class='title'>
+  <h1 id='title'>
+    {{ title }}
+  </h1>
+  </section>
+  <main>

--- a/markata/plugins/default_post_template.html
+++ b/markata/plugins/default_post_template.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta name="generator" content="HTML Tidy for HTML5 for Linux version 5.2.0">
   <title>{{ title }}</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/markata/plugins/default_post_template.html
+++ b/markata/plugins/default_post_template.html
@@ -421,10 +421,17 @@
   .slider.round:before {
   border-radius: 50%;
   }
+
   </style>
 </head>
-<body>
 
+  <nav>
+    {% for text, link in config.get('nav', {}).items() %}
+      <a href='{{link}}'>{{text}}</a>
+    {% endfor %}
+  </nav>
+
+<body>
   <div>
     <label id="theme-switch" class="theme-switch" for="checkbox-theme" title='light/dark mode toggle'>
       <input type="checkbox" id="checkbox-theme">

--- a/markata/plugins/feeds.py
+++ b/markata/plugins/feeds.py
@@ -187,10 +187,9 @@ def configure(markata: Markata) -> None:
     """
     configure the default values for the feeds plugin
     """
-    config = markata.config.get("feeds", {})
-    if config is None:
+    if "feeds" not in markata.config.keys():
         markata.config["feeds"] = dict()
-        config = markata.config.get("feeds", {})
+    config = markata.config.get("feeds", dict())
     if "archive" not in config.keys():
         config["archive"] = dict()
         config["archive"]["filter"] = "True"

--- a/markata/plugins/generator.py
+++ b/markata/plugins/generator.py
@@ -7,11 +7,15 @@ from markata.hookspec import hook_impl
 
 @hook_impl(trylast=True)
 def render(markata: Markata) -> None:
+    should_prettify = markata.config.get("prettify_html", False)
     for article in markata.iter_articles("add ssg tag"):
         soup = BeautifulSoup(article.html, features="lxml")
         tag = soup.new_tag("meta")
         tag.attrs["content"] = f"markata {__version__}"
         tag.attrs["name"] = "generator"
         soup.head.append(tag)
-        article.soup = soup
-        article.html = soup.prettify()
+
+        if should_prettify:
+            article.html = soup.prettify()
+        else:
+            article.html = str(soup)

--- a/markata/plugins/heading_link.py
+++ b/markata/plugins/heading_link.py
@@ -23,6 +23,7 @@ def post_render(markata: Markata) -> None:
     """
 
     config = markata.get_plugin_config(__file__)
+    should_prettify = markata.config.get("prettify_html", False)
     with markata.cache as cache:
         for article in markata.iter_articles("link headers"):
 
@@ -37,14 +38,14 @@ def post_render(markata: Markata) -> None:
             html_from_cache = cache.get(key)
 
             if html_from_cache is None:
-                html = link_headings(article)
+                html = link_headings(article, should_prettify)
                 cache.add(key, html, expire=config["cache_expire"])
             else:
                 html = html_from_cache
             article.html = html
 
 
-def link_headings(article: "Post") -> Any:
+def link_headings(article: "Post", prettify: bool = False) -> Any:
     """
     Use BeautifulSoup to find all headings and run link_heading on them.
     """
@@ -55,8 +56,9 @@ def link_headings(article: "Post") -> Any:
             and heading.get("id", "") != "title"
         ):
             link_heading(soup, heading)
-    html = soup.prettify()
-    return html
+    if prettify:
+        return soup.prettify()
+    return str(soup)
 
 
 def link_heading(soup: "bs4.BeautifulSoup", heading: "bs4.element.Tag") -> None:

--- a/markata/plugins/manifest.py
+++ b/markata/plugins/manifest.py
@@ -33,6 +33,7 @@ def render(markata: "MarkataIcons") -> None:
     with open(filepath, "w+") as f:
         json.dump(manifest, f, ensure_ascii=True, indent=4)
     config = markata.get_plugin_config(__file__)
+    should_prettify = markata.config.get("prettify_html", False)
     with markata.cache as cache:
         for article in markata.iter_articles("add manifest link"):
             key = markata.make_hash(
@@ -50,7 +51,10 @@ def render(markata: "MarkataIcons") -> None:
                 link.attrs["href"] = "/manifest.json"
                 soup.head.append(link)
 
-                html = soup.prettify()
+                if should_prettify:
+                    html = soup.prettify()
+                else:
+                    html = str(soup)
                 cache.add(key, html, expire=config["cache_expire"])
             else:
                 html = html_from_cache

--- a/markata/plugins/pyinstrument.py
+++ b/markata/plugins/pyinstrument.py
@@ -36,7 +36,7 @@ def configure(markata: MarkataInstrument) -> None:
 @register_attr("profiler")
 def glob(markata: MarkataInstrument) -> None:
     "start the profiler as soon as possible"
-    if markata.should_profile and 'profiler' not in markata.__dict__.keys():
+    if markata.should_profile and "profiler" not in markata.__dict__.keys():
         try:
             markata.profiler = Profiler(async_mode="disabled")
             markata.profiler.start()

--- a/markata/plugins/pyinstrument.py
+++ b/markata/plugins/pyinstrument.py
@@ -36,7 +36,7 @@ def configure(markata: MarkataInstrument) -> None:
 @register_attr("profiler")
 def glob(markata: MarkataInstrument) -> None:
     "start the profiler as soon as possible"
-    if markata.should_profile:
+    if markata.should_profile and 'profiler' not in markata.__dict__.keys():
         try:
             markata.profiler = Profiler(async_mode="disabled")
             markata.profiler.start()

--- a/markata/plugins/pyinstrument.py
+++ b/markata/plugins/pyinstrument.py
@@ -14,7 +14,6 @@ except ModuleNotFoundError:
     "ignore if pyinstrument does not exist"
     ...
 
-
 class MarkataInstrument(Markata):
     should_profile = False
     profiler = None
@@ -38,7 +37,7 @@ def glob(markata: MarkataInstrument) -> None:
     "start the profiler as soon as possible"
     if markata.should_profile:
         try:
-            markata.profiler = Profiler()
+            markata.profiler = Profiler(async_mode='disabled')
             markata.profiler.start()
         except NameError:
             "ignore if Profiler does not exist"

--- a/markata/plugins/pyinstrument.py
+++ b/markata/plugins/pyinstrument.py
@@ -14,6 +14,7 @@ except ModuleNotFoundError:
     "ignore if pyinstrument does not exist"
     ...
 
+
 class MarkataInstrument(Markata):
     should_profile = False
     profiler = None
@@ -37,7 +38,7 @@ def glob(markata: MarkataInstrument) -> None:
     "start the profiler as soon as possible"
     if markata.should_profile:
         try:
-            markata.profiler = Profiler(async_mode='disabled')
+            markata.profiler = Profiler(async_mode="disabled")
             markata.profiler.start()
         except NameError:
             "ignore if Profiler does not exist"

--- a/markata/plugins/render_markdown.py
+++ b/markata/plugins/render_markdown.py
@@ -31,6 +31,7 @@ def configure(markata: "MarkataMarkdown") -> None:
 
 
 @hook_impl(tryfirst=True)
+@register_attr("articles")
 def render(markata: "Markata") -> None:
     config = markata.get_plugin_config(__file__)
     with markata.cache as cache:

--- a/markata/plugins/seo.py
+++ b/markata/plugins/seo.py
@@ -157,6 +157,7 @@ def render(markata: Markata) -> None:
     twitter_creator = _get_or_warn(markata.config, "twitter_creator", "")
     twitter_card = _get_or_warn(markata.config, "twitter_card", "summary_large_image")
     config_seo = markata.config.get("seo", {})
+    should_prettify = markata.config.get("prettify_html", False)
 
     with markata.cache as cache:
         for article in markata.iter_articles("add seo tags from seo.py"):
@@ -206,7 +207,10 @@ def render(markata: Markata) -> None:
                     meta_url.attrs["content"] = f'{url}/{article.metadata["slug"]}/'
                 soup.head.append(meta_url)
 
-                html = soup.prettify()
+                if should_prettify:
+                    html = soup.prettify()
+                else:
+                    html = str(soup)
                 cache.add(key, html, expire=markata.config["default_cache_expire"])
 
             else:

--- a/markata/plugins/setup_logging.py
+++ b/markata/plugins/setup_logging.py
@@ -1,0 +1,219 @@
+"""
+Setup Logging hook sets up the RichHandler for pretty console logs, and file logs to the configured markata's configured `log_dir`, or
+`output_dir/_logs` if `log_dir` is not configured.  The log file will be named after the `<levelname>.log`
+
+## The log files
+
+There will be 6 log files created based on log level and file type.
+
+```
+markout/_logs
+├── debug
+│   └── index.html
+├── debug.log
+├── info
+│   └── index.html
+├── info.log
+├── warning
+│   └── index.html
+└── warning.log
+```
+
+## Configuration
+
+Ensure that setup_logging is in your hooks.  You can check if `setup_logging`
+is in your hooks by running `markata list --hooks` from your terminal and
+checking the output, or creating an instance of `Markata()` and checking the
+`Markata().hooks` attribute.  If its missing or you wan to be more explicit,
+you can add `setup_logging` to your `markata.toml` `[markata.hooks]`.
+
+``` toml
+[markata]
+
+# make sure its in your list of hooks
+hooks=[
+   "markata.plugins.setup_logging",
+   ]
+```
+
+## Log Template
+``` toml
+[markata]
+
+# make sure its in your list of hooks
+hooks=[
+   "markata.plugins.setup_logging",
+   ]
+
+# point log template to the path of your logging template
+log_template='templates/log_template.html'
+```
+
+You can see the latest default `log_template` on
+[GitHub](https://github.com/WaylonWalker/markata/blob/main/markata/plugins/default_log_template.html)
+
+## Disable Logging
+
+If you do not want logging, you can explicityly disable it by adding it to your
+`[markata.disabled_hooks]` array in your `[markata.toml]`
+
+``` toml
+[markata]
+
+# make sure its in your list of hooks
+disabled_hooks=[
+   "markata.plugins.setup_logging",
+   ]
+```
+
+"""
+import datetime
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from jinja2 import Template, Undefined
+from rich.logging import RichHandler
+
+from markata.hookspec import hook_impl
+
+if TYPE_CHECKING:
+    from markata import Markata
+
+
+class SilentUndefined(Undefined):
+    def _fail_with_undefined_error(self, *args, **kwargs):
+        return ""
+
+
+def has_rich_handler() -> bool:
+    """
+    Returns a boolean whether or not there is a RichHandler attached to the
+    root logger.
+    """
+
+    logger = logging.getLogger()
+    return bool([h for h in logger.handlers if isinstance(h, RichHandler)])
+
+
+def has_file_handler(log_file: Path) -> bool:
+    logger = logging.getLogger()
+    existing_logger_files = [
+        handler.baseFilename
+        for handler in logger.handlers
+        if isinstance(handler, logging.FileHandler)
+    ]
+    return str(log_file.absolute()) in existing_logger_files
+
+
+def setup_log(markata: "Markata", level: int = logging.INFO) -> Path:
+    path = setup_html_log(markata, level)
+    setup_text_log(markata, level)
+    return path
+
+
+def setup_text_log(markata: "Markata", level: int = logging.INFO) -> Path:
+    """
+    sets up a plain text log in markata's configured `log_dir`, or
+    `output_dir/_logs` if `log_dir` is not configured.  The log file will be
+    named after the `<levelname>.log`
+    """
+    log_file = Path(
+        str(
+            markata.config.get(
+                "log_dir",
+                Path(str(markata.config.get("output_dir", "markout")))
+                / "_logs"
+                / (logging.getLevelName(level).lower() + ".log"),
+            )
+        )
+    )
+    if has_file_handler(log_file):
+        return log_file
+
+    if not log_file.parent.exists():
+        log_file.parent.mkdir(parents=True)
+    fh = logging.FileHandler(log_file)
+    fh.setLevel(level)
+    fh_formatter = logging.Formatter(
+        "%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+    )
+    fh.setFormatter(fh_formatter)
+    logging.getLogger("").addHandler(fh)
+
+    return log_file
+
+
+def setup_html_log(markata: "Markata", level: int = logging.INFO) -> Path:
+    """
+    sets up an html log in markata's configured `log_dir`, or
+    `output_dir/_logs` if `log_dir` is not configured.  The log file will be
+    named after the `<levelname>/index.html`.  The goal of this is to give
+    """
+
+    log_file = Path(
+        str(
+            markata.config.get(
+                "log_dir",
+                Path(str(markata.config.get("output_dir", "markout")))
+                / "_logs"
+                / logging.getLevelName(level).lower()
+                / "index.html",
+            )
+        )
+    )
+
+    if has_file_handler(log_file):
+        return log_file
+
+    if not log_file.parent.exists():
+        log_file.parent.mkdir(parents=True)
+    if not log_file.exists():
+        template_file = Path(
+            str(
+                markata.config.get(
+                    "log_template", Path(__file__).parent / "default_log_template.html"
+                )
+            )
+        )
+        template = Template(template_file.read_text(), undefined=SilentUndefined)
+        log_header = template.render(
+            title=str(markata.config.get("title", "markata build")) + " logs",
+            config=markata.config,
+        )
+        log_file.write_text(log_header)
+    with open(log_file, "a") as f:
+        command = Path(sys.argv[0]).name + " " + " ".join(sys.argv[1:])
+        f.write(
+            f"""
+            <div style="width: 100%; height: 20px; margin-top: 5rem; border-bottom: 1px solid goldenrod; text-align: center">
+    <span style="padding: 0 10px;">
+    {datetime.datetime.now()} running "{command}"
+    </span>
+    </div>
+    """
+        )
+    fh = logging.FileHandler(log_file)
+    fh.setLevel(level)
+    fh_formatter = logging.Formatter(
+        "<li><p><span class='time'>%(asctime)s</span> <span class='name %(name)s'>%(name)-12s</span> <span class='levelname %(levelname)s'>%(levelname)-8s</span></p><p class='message'>%(message)s</p></li>"
+    )
+    fh.setFormatter(fh_formatter)
+    logging.getLogger("").addHandler(fh)
+
+    return log_file
+
+
+@hook_impl(tryfirst=True)
+def configure(markata: "Markata") -> None:
+    setup_log(markata, logging.DEBUG)
+    setup_log(markata, logging.INFO)
+    setup_log(markata, logging.WARNING)
+
+    if not has_rich_handler():
+        console = RichHandler(rich_tracebacks=True)
+        console.setLevel(logging.INFO)
+        formatter = logging.Formatter("%(message)s")
+        console.setFormatter(formatter)
+        logging.getLogger("").addHandler(console)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0.b1
+current_version = 0.3.0.b2
 commit = True
 tag = True
 parse = ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0.b2
+current_version = 0.3.0.b3
 commit = True
 tag = True
 parse = ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0.b0
+current_version = 0.3.0.b1
 commit = True
 tag = True
 parse = ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0.b7
+current_version = 0.3.0.b8
 commit = True
 tag = True
 parse = ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0.b3
+current_version = 0.3.0.b4
 commit = True
 tag = True
 parse = ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,34 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0.b0
 commit = True
 tag = True
+parse = ^
+	(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+	(\.(?P<prekind>a|alpha|b|beta|d|dev|rc)
+	(?P<pre>\d+)  # pre-release version num
+	)?
+	(\.(?P<postkind>post)(?P<post>\d+))?  # post-release
+serialize = 
+	{major}.{minor}.{patch}.{prekind}{pre}.{postkind}{post}
+	{major}.{minor}.{patch}.{prekind}{pre}
+	{major}.{minor}.{patch}.{postkind}{post}
+	{major}.{minor}.{patch}
 
 [bumpversion:file:setup.py]
 
 [bumpversion:file:markata/__init__.py]
+
+[bumpversion:part:prekind]
+optional_value = _
+values = 
+	_
+	dev
+	d
+	alpha
+	a
+	beta
+	b
+	rc
 
 [pydocstyle]
 inherit = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0.b5
+current_version = 0.3.0.b6
 commit = True
 tag = True
 parse = ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0.b6
+current_version = 0.3.0.b7
 commit = True
 tag = True
 parse = ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0.b4
+current_version = 0.3.0.b5
 commit = True
 tag = True
 parse = ^

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.3.0.b7",
+    version="0.3.0.b8",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.3.0.b4",
+    version="0.3.0.b5",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.3.0.b1",
+    version="0.3.0.b2",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.3.0.b0",
+    version="0.3.0.b1",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.3.0.b2",
+    version="0.3.0.b3",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.3.0.b5",
+    version="0.3.0.b6",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.3.0.b6",
+    version="0.3.0.b7",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.2.0",
+    version="0.3.0.b0",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 setup(
     name=NAME,
-    version="0.3.0.b3",
+    version="0.3.0.b4",
     url="https://markata.dev",
     author="Waylon Walker",
     author_email="waylon@waylonwalker.com",


### PR DESCRIPTION
* feat: add html logging with [setup_logging](/markata/plugins/setup_logging/)
  plugin is all new closes #37
* fix: remove HTML tidy as the site generator tag
* feat: create configurable [navbar](https://markata.dev/nav)
* perf: prevent double runs on pre-render and post-render #39
* perf: prevent duplicate ruun from to_dict calling pre-render #53
   * `to_dict` only runs up to `render` phase if necessary as directed by `register_attr`
* perf: only prettify if configured #54
* fix: pyinstrument will not create a second profiler causing it to end in errors #50
* fix: sites without feeds config do not create an index #55

### Double Runs

Previously markata would catch AttributeError and run the previous step any
time you ran a step too early.  The way this was implemented caused some steps
such as pre-render and post-render to run twice with every single run.

This change will no longer catch attribute errors. If you run into any issues
with your plugins not running before asking for attributes created by your
plugin make sure that you implement the
[@register_attr](https://markata.dev/markata/hookspec/#register_attr-function)
decorator.

### Prettify

prettify html has been turned off by default as beautifulsoup4 prettify was
taking a significant time, and was often popping up as the slowest parts in my
personal `_profile`.  If you want to continue running prettify throughout the
build you can set a flag in your config to continue running prettify.

``` toml
[markata]
prettify_html = true
```