### PR TITLE
feature create slugify-migration script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## 0.5.0-dev
 
+* Remove unused function clif that was the original entrypoint #81
 * Fix #33 sluggify paths #69 **BREAKING CHANGE** 0.5.dev6
 * Configurable template #70 0.5.dev5
 * Fix #40 Images overlfow outside of body #66 0.5.dev3
 * Created entrypoint hook allowing for users to extend marka with jinja
   exensions #60 0.5.0.dev2
 * Moved to PEP 517 build #59 0.5.0.dev1
+* markata.plugins.redirects will create redirect html files as a backup when
+  server-side redirects fail, or the user does not have the ability to issue. #76
+* create a slugify migration script #82
 
 ### sluggify paths
 
@@ -16,17 +20,31 @@ name of the original file.
 
 For examples of how `python-slugify` will change your url's see the
 [project's home page](https://pypi.org/project/python-slugify/)
-
 #### OPTING OUT
 
-If you have an existing site and do not want to implement redirects, or simply
+
 do not want to use slugify, you can opt out by setting `slugify=False` in your
 `markata.toml`.
+If you have an existing site and do not want to implement redirects, or simply
 
 ``` toml
 [markata]
 slugify=false
 ```
+
+#### Migrating to slugify
+
+From the command line with `markata>=0.5.0` installed run the
+migration script from the command line to create a redirects file in the
+default location.  This should avoid all 404's as it will create a redirects
+file that many static hosting providers will issue a server-side 301 for, and
+for those that don't, markata.plugins.redirects creates a redirect html page,
+that will kick in as a backup.
+
+``` bash
+python -m markata.scripts.migrate_to_slugify
+```
+
 
 ### configurable page template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.5.0-dev
 
-* Remove unused function clif that was the original entrypoint #81
-* Fix #33 sluggify paths #69 **BREAKING CHANGE** 0.5.dev6
+* Remove unused function clif that was the original entrypoint #81 0.5.0dev8
+* Fix #33 sluggify paths #69 **BREAKING CHANGE** 0.5.0dev6
 * Configurable template #70 0.5.dev5
 * Fix #40 Images overlfow outside of body #66 0.5.dev3
 * Created entrypoint hook allowing for users to extend marka with jinja
@@ -19,9 +19,10 @@
 name of the original file.
 
 For examples of how `python-slugify` will change your url's see the
-[project's home page](https://pypi.org/project/python-slugify/)
-#### OPTING OUT
+[project's home page](https://pypi.org/project/python-slugify/).  One
+difference is that `markata` will leave `/`'s for routing in the slugs.
 
+#### OPTING OUT
 
 do not want to use slugify, you can opt out by setting `slugify=False` in your
 `markata.toml`.

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -81,6 +81,7 @@ DEFAULT_HOOKS = [
     "markata.plugins.tui",
     "markata.plugins.jinja_md",
     "markata.plugins.setup_logging",
+    "markata.plugins.redirects",
 ]
 
 DEFUALT_CONFIG = {

--- a/markata/plugins/flat_slug.py
+++ b/markata/plugins/flat_slug.py
@@ -46,8 +46,10 @@ def pre_render(markata: "Markata") -> None:
     """
     should_slugify = markata.config.get("slugify", True)
     for article in markata.iter_articles(description="creating slugs"):
-        stem = article.get("slug", Path(article["path"]).stem)
+        stem = article.get(
+            "slug", Path(article.get("path", article.get("title", ""))).stem
+        )
         if should_slugify:
-            article["slug"] = slugify(stem)
+            article["slug"] = "/".join([slugify(s) for s in stem.split("/")])
         else:
             article["slug"] = stem

--- a/markata/scripts/migrate_to_slugify.py
+++ b/markata/scripts/migrate_to_slugify.py
@@ -1,0 +1,39 @@
+"""
+Slugify migration for projects moving from markata<0.5.0 into markata>=0.5.0
+
+to run this script install markata>=0.5.0 and run the following.
+
+``` bash
+python -m markata.scripts.migrate_to_slugify
+```
+
+Then make sure that you do not explicity turn off slugify and your site is
+going to be on to better urls.
+
+``` toml
+[markata]
+slugify=false
+```
+"""
+from pathlib import Path
+
+from slugify import slugify
+
+from markata import Markata
+
+if __name__ == "__main__":
+    m = Markata()
+    m.config["slugify"] = False
+
+    original_urls = m.map("slug")
+    redirects = [o.ljust(60) + slugify(o) for o in original_urls if slugify(o) != o]
+    assets_dir: str = str(m.config.get("assets_dir", "static"))
+    redirects_file = Path(
+        str(m.config.get("redirects", Path(assets_dir) / "_redirects"))
+    )
+    redirects_file.touch()
+    with open(redirects_file, "a") as f:
+        f.write("\n")
+        f.write("# marakta migrate to slugify redirects")
+        f.write("\n".join(redirects))
+        f.write("\n")

--- a/markata/scripts/migrate_to_slugify.py
+++ b/markata/scripts/migrate_to_slugify.py
@@ -26,7 +26,9 @@ if __name__ == "__main__":
     m.config["slugify"] = False
 
     original_urls = m.map("slug")
-    redirects = [o.ljust(60) + slugify(o) for o in original_urls if slugify(o) != o]
+    redirects = [
+        "/" + o.ljust(60) + "/" + slugify(o) for o in original_urls if slugify(o) != o
+    ]
     assets_dir: str = str(m.config.get("assets_dir", "static"))
     redirects_file = Path(
         str(m.config.get("redirects", Path(assets_dir) / "_redirects"))
@@ -34,6 +36,6 @@ if __name__ == "__main__":
     redirects_file.touch()
     with open(redirects_file, "a") as f:
         f.write("\n")
-        f.write("# marakta migrate to slugify redirects")
+        f.write("# marakta migrate to slugify redirects\n")
         f.write("\n".join(redirects))
         f.write("\n")

--- a/markata/scripts/migrate_to_slugify.py
+++ b/markata/scripts/migrate_to_slugify.py
@@ -21,13 +21,20 @@ from slugify import slugify
 
 from markata import Markata
 
+
+def routed_slugify(text):
+    return "/".join([slugify(s) for s in text.split("/")])
+
+
 if __name__ == "__main__":
     m = Markata()
     m.config["slugify"] = False
 
     original_urls = m.map("slug")
     redirects = [
-        "/" + o.ljust(60) + "/" + slugify(o) for o in original_urls if slugify(o) != o
+        "/" + o.ljust(60) + "/" + routed_slugify(o)
+        for o in original_urls
+        if routed_slugify(o) != o
     ]
     assets_dir: str = str(m.config.get("assets_dir", "static"))
     redirects_file = Path(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ ignore_errors = true
 
 [tool.isort]
 profile = "black"
-known_third_party = ["PIL", "anyconfig", "bs4", "checksumdir", "commonmark", "dateutil", "diskcache", "feedgen", "frontmatter", "jinja2", "markdown", "more_itertools", "pathspec", "pkg_resources", "pluggy", "pydantic", "pytest", "pytz", "rich", "slugify", "textual", "typer", "yaml"]
+known_third_party = ["PIL", "anyconfig", "bs4", "checksumdir", "commonmark", "conftest", "dateutil", "diskcache", "feedgen", "frontmatter", "jinja2", "markdown", "more_itertools", "pathspec", "pkg_resources", "pluggy", "pydantic", "pytest", "pytz", "rich", "slugify", "textual", "typer", "yaml"]
 
 [tool.hatch.version]
 path = "markata/__about__.py"

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,0 +1,22 @@
+import os
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def set_directory(path: str) -> None:
+    """Sets the cwd within the context
+
+    Args:
+        path (Path): The path to the cwd
+
+    Yields:
+        None
+    """
+
+    origin = Path().absolute()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(origin)

--- a/tests/plugins/test_flat_slug.py
+++ b/tests/plugins/test_flat_slug.py
@@ -1,0 +1,73 @@
+import pytest
+
+from markata import Markata
+from markata.plugins import flat_slug
+
+
+@pytest.mark.parametrize(
+    "article, slug",
+    [
+        ({"slug": "post_one"}, "post-one"),
+        ({"slug": "post-one"}, "post-one"),
+        ({"slug": "post one"}, "post-one"),
+        ({"slug": "POST_ONE"}, "post-one"),
+        ({"slug": "posts/post_one"}, "posts/post-one"),
+        ({"slug": "posts/post-one"}, "posts/post-one"),
+        ({"slug": "posts/post one"}, "posts/post-one"),
+        ({"slug": "posts/POST_ONE"}, "posts/post-one"),
+        ({"slug": "POSTS/post_one"}, "posts/post-one"),
+        ({"slug": "/posts/post_one"}, "/posts/post-one"),
+    ],
+)
+def test_flat_slug(article, slug) -> None:
+    "ensure that the explicit workflow works"
+    m = Markata()
+    m.articles = [article]
+    flat_slug.pre_render(m)
+
+    assert m.articles[0]["slug"] == slug
+
+
+@pytest.mark.parametrize(
+    "article, slug",
+    [
+        ({"path": "post_one.md"}, "post-one"),
+        ({"path": "post-one.md"}, "post-one"),
+        ({"path": "post one.md"}, "post-one"),
+        ({"path": "POST_ONE.md"}, "post-one"),
+        ({"path": "posts/post_one.md"}, "posts/post-one"),
+        ({"path": "posts/post-one.md"}, "posts/post-one"),
+        ({"path": "posts/post one.md"}, "posts/post-one"),
+        ({"path": "posts/POST_ONE.md"}, "posts/post-one"),
+        ({"path": "POSTS/post_one.md"}, "posts/post-one"),
+        ({"path": "/posts/post_one.md"}, "/posts/post-one"),
+    ],
+)
+def test_flat_slug_path(article, slug) -> None:
+    "ensure that the second most explicit workflow works"
+    m = Markata()
+    m.articles = [article]
+    flat_slug.pre_render(m)
+
+
+@pytest.mark.parametrize(
+    "article, slug",
+    [
+        ({"title": "post_one"}, "post-one"),
+        ({"title": "post-one"}, "post-one"),
+        ({"title": "post one"}, "post-one"),
+        ({"title": "POST_ONE"}, "post-one"),
+        ({"title": "/post_one"}, "post-one"),
+        ({"title": "posts/post_one"}, "posts/post-one"),
+        ({"title": "posts/post-one"}, "posts/post-one"),
+        ({"title": "posts/post one"}, "posts/post-one"),
+        ({"title": "posts/POST_ONE"}, "posts/post-one"),
+        ({"title": "POSTS/post_one"}, "posts/post-one"),
+        ({"title": "/posts/post_one"}, "/posts/post-one"),
+    ],
+)
+def test_flat_slug_title(article, slug) -> None:
+    "ensure that the second most explicit workflow works"
+    m = Markata()
+    m.articles = [article]
+    flat_slug.pre_render(m)

--- a/tests/plugins/test_redirects.py
+++ b/tests/plugins/test_redirects.py
@@ -1,33 +1,13 @@
 """
 Tests the redirects plugin
 """
-import os
-from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+from conftest import set_directory
 
 from markata import Markata
 from markata.plugins import redirects
-
-
-@contextmanager
-def set_directory(path: str) -> None:
-    """Sets the cwd within the context
-
-    Args:
-        path (Path): The path to the cwd
-
-    Yields:
-        None
-    """
-
-    origin = Path().absolute()
-    try:
-        os.chdir(path)
-        yield
-    finally:
-        os.chdir(origin)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Creates a migration script so that sites created before 0.5.0 can use slugify,
which creates clean urls,  without creating 404's for their users.

## Usage

From the command line with `markata>=0.5.0` installed users can run the
migration script from their command line to create a redirects file in the
default location.

``` bash
python -m markata.scripts.migrate_to_slugify
```

## FIX

This pr also fixes a previous error in the way markata used slugify in the
previous pre-releases.  It got rid of all subroutes all together.

