### PR TITLE
Configurable post head

### DIFF
--- a/markata/plugins/default_post_template.html
+++ b/markata/plugins/default_post_template.html
@@ -443,9 +443,8 @@
 
   </style>
 
-  {% for head in config.get('head', []) %}
-    {{ head.get('text', '') }}
-  {% endfor %}
+  {{ config.get('head', {}).pop('text') if 'text' in config.get('head',{}).keys() }}{% for tag, meta in config.get('head', {}).items() %}{% for _meta in meta %}
+  <{{ tag }} {% for attr, value in _meta.items() %}{{ attr }}="{{ value }}"{% endfor %}/> {% endfor %}{% endfor %}
 </head>
 
   <nav>

--- a/markata/plugins/post_template.py
+++ b/markata/plugins/post_template.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from jinja2 import Template, Undefined
+from more_itertools import flatten
 
 from markata.hookspec import hook_impl
 
@@ -12,6 +13,51 @@ if TYPE_CHECKING:
 class SilentUndefined(Undefined):
     def _fail_with_undefined_error(self, *args, **kwargs):
         return ""
+
+
+@hook_impl
+def configure(markata: "Markata") -> None:
+    '''
+    massages the configuration limitations of toml to allow a little bit easier
+    experience to the end user making configurations while allowing an simpler
+    jinja template.
+
+    Adding this snippet to your post template will allow users to use the same
+    configuration as the default template.
+
+    ``` html
+    {{ config.get('head', {}).pop('text') if 'text' in config.get('head',{}).keys() }}{% for tag, meta in config.get('head', {}).items() %}{% for _meta in meta %}
+    <{{ tag }} {% for attr, value in _meta.items() %}{{ attr }}="{{ value }}"{% endfor %}/> {% endfor %}{% endfor %}
+    ```
+
+    Here is an example config
+
+    ``` toml
+    [[markata.head.text]]
+    value = """
+    some script
+    """
+
+    [[markata.head.text]]
+    value="""
+    some style
+    """
+
+    [[markata.head.meta]]
+    name = "og:type"
+    property = "og:type"
+    content = "article"
+
+    [[markata.head.meta]]
+    name = "og:author"
+    property = "og:author"
+    content = "Waylon Walker"
+    ```
+    '''
+
+    markata.config["head"]["text"] = "\n".join(
+        flatten([t.values() for t in markata.config["head"]["text"]])
+    )
 
 
 @hook_impl

--- a/markata/plugins/post_template.py
+++ b/markata/plugins/post_template.py
@@ -55,9 +55,14 @@ def configure(markata: "Markata") -> None:
     ```
     '''
 
-    markata.config["head"]["text"] = "\n".join(
-        flatten([t.values() for t in markata.config["head"]["text"]])
-    )
+    raw_text = markata.config.get("head", {}).get("text", "")
+
+    if isinstance(raw_text, dict):
+        markata.config["head"]["text"] = "\n".join(
+            flatten([t.values() for t in raw_text])
+        )
+    if isinstance(raw_text, list):
+        markata.config["head"]["text"] = "\n".join(flatten([t for t in raw_text]))
 
 
 @hook_impl

--- a/markata/plugins/post_template.py
+++ b/markata/plugins/post_template.py
@@ -1,3 +1,58 @@
+"""
+
+
+## Add head configuration
+
+This snippet allows users to configure their head in `markata.toml`.
+
+``` html
+{{ config.get('head', {}).pop('text') if 'text' in config.get('head',{}).keys() }}{% for tag, meta in config.get('head', {}).items() %}{% for _meta in meta %}
+<{{ tag }} {% for attr, value in _meta.items() %}{{ attr }}="{{ value }}"{% endfor %}/> {% endfor %}{% endfor %}
+```
+
+Users can specify any sort of tag in their `markata.toml`
+
+```
+[[markata.head.meta]]
+name = "og:type"
+content = "article"
+
+[[markata.head.meta]]
+name = "og:author"
+content = "Waylon Walker"
+```
+
+The above configuration becomes this once rendered.
+
+``` html
+<meta name='og:type' content='article' />
+<meta name='og:Author' content='Waylon Walker' />
+```
+
+Optionally users can also specify plain text to be appended to the head of
+their documents.  This works well for things that involve full blocks.
+
+``` toml
+[[markata.head.text]]
+value = '''
+<script>
+    console.log('hello world')
+</script>
+'''
+
+[[markata.head.text]]
+value='''
+html  {
+    font-family: "Space Mono", monospace;
+    background: var(--color-bg);
+    color: var(--color-text);
+}
+'''
+```
+
+
+
+"""
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,49 +72,12 @@ class SilentUndefined(Undefined):
 
 @hook_impl
 def configure(markata: "Markata") -> None:
-    '''
+    """
     Massages the configuration limitations of toml to allow a little bit easier
     experience to the end user making configurations while allowing an simpler
-    jinja template.
-
-    Adding this snippet to your post template will allow users to use the same
-    configuration as the default template.
-
-    ``` html
-    {{ config.get('head', {}).pop('text') if 'text' in config.get('head',{}).keys() }}{% for tag, meta in config.get('head', {}).items() %}{% for _meta in meta %}
-    <{{ tag }} {% for attr, value in _meta.items() %}{{ attr }}="{{ value }}"{% endfor %}/> {% endfor %}{% endfor %}
-    ```
-
-    Here is an example config that adds
-
-    ``` toml
-    [[markata.head.text]]
-    value = """
-    <script>
-      console.log('hello world')
-    </script>
+    jinja template.  This enablees the use of the `markata.head.text` list in
+    configuration.
     """
-
-    [[markata.head.text]]
-    value="""
-    html  {
-      font-family: "Space Mono", monospace;
-      background: var(--color-bg);
-      color: var(--color-text);
-    }
-    """
-
-    [[markata.head.meta]]
-    name = "og:type"
-    property = "og:type"
-    content = "article"
-
-    [[markata.head.meta]]
-    name = "og:author"
-    property = "og:author"
-    content = "Waylon Walker"
-    ```
-    '''
 
     raw_text = markata.config.get("head", {}).get("text", "")
 
@@ -67,8 +85,6 @@ def configure(markata: "Markata") -> None:
         markata.config["head"]["text"] = "\n".join(
             flatten([t.values() for t in raw_text])
         )
-    # if isinstance(raw_text, list):
-    #     markata.config["head"]["text"] = "\n".join(flatten([t for t in raw_text]))
 
 
 @hook_impl

--- a/markata/plugins/post_template.py
+++ b/markata/plugins/post_template.py
@@ -57,12 +57,12 @@ def configure(markata: "Markata") -> None:
 
     raw_text = markata.config.get("head", {}).get("text", "")
 
-    if isinstance(raw_text, dict):
+    if isinstance(raw_text, list):
         markata.config["head"]["text"] = "\n".join(
             flatten([t.values() for t in raw_text])
         )
-    if isinstance(raw_text, list):
-        markata.config["head"]["text"] = "\n".join(flatten([t for t in raw_text]))
+    # if isinstance(raw_text, list):
+    #     markata.config["head"]["text"] = "\n".join(flatten([t for t in raw_text]))
 
 
 @hook_impl

--- a/markata/plugins/post_template.py
+++ b/markata/plugins/post_template.py
@@ -18,7 +18,7 @@ class SilentUndefined(Undefined):
 @hook_impl
 def configure(markata: "Markata") -> None:
     '''
-    massages the configuration limitations of toml to allow a little bit easier
+    Massages the configuration limitations of toml to allow a little bit easier
     experience to the end user making configurations while allowing an simpler
     jinja template.
 
@@ -30,17 +30,23 @@ def configure(markata: "Markata") -> None:
     <{{ tag }} {% for attr, value in _meta.items() %}{{ attr }}="{{ value }}"{% endfor %}/> {% endfor %}{% endfor %}
     ```
 
-    Here is an example config
+    Here is an example config that adds
 
     ``` toml
     [[markata.head.text]]
     value = """
-    some script
+    <script>
+      console.log('hello world')
+    </script>
     """
 
     [[markata.head.text]]
     value="""
-    some style
+    html  {
+      font-family: "Space Mono", monospace;
+      background: var(--color-bg);
+      color: var(--color-text);
+    }
     """
 
     [[markata.head.meta]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
  "pre-commit",
  "pytest",
  "pytest-cov",
+ "pytest-rich",
  "pytest-mock",
  "pytest-tmp-files",
 ]
@@ -124,7 +125,7 @@ ignore_errors = true
 
 [tool.isort]
 profile = "black"
-known_third_party = ["PIL", "anyconfig", "bs4", "checksumdir", "commonmark", "conftest", "dateutil", "diskcache", "feedgen", "frontmatter", "jinja2", "markdown", "more_itertools", "pathspec", "pkg_resources", "pluggy", "pydantic", "pytest", "pytz", "rich", "slugify", "textual", "typer", "yaml"]
+known_third_party = ["PIL", "anyconfig", "bs4", "checksumdir", "commonmark", "conftest", "dateutil", "diskcache", "feedgen", "frontmatter", "jinja2", "markdown", "more_itertools", "pathspec", "pkg_resources", "pluggy", "pydantic", "pytest", "pytz", "rich", "slugify", "textual", "toml", "typer", "yaml"]
 
 [tool.hatch.version]
 path = "markata/__about__.py"
@@ -150,6 +151,7 @@ dependencies = [
  "isort",
  "pytest",
  "pytest-cov",
+ "pytest-rich",
  "pytest-tmp-files",
  "seed-isort-config",
 ]
@@ -162,6 +164,7 @@ dependencies = [
  "isort",
  "pytest",
  "pytest-cov",
+ "pytest-rich",
  "pytest-tmp-files",
  "seed-isort-config",
 ]

--- a/tests/plugins/test_default_post_template.py
+++ b/tests/plugins/test_default_post_template.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import toml
+from conftest import set_directory
+
+from markata import Markata
+from markata.plugins import post_template
+
+
+def test_head_config_text_str(tmp_path):
+    with set_directory(tmp_path):
+        m = Markata()
+        m.config["head"] = {}
+        m.config["head"]["text"] = "here"
+        post_template.configure(m)
+        assert m.config["head"]["text"] == "here"
+
+
+def test_head_config_text_dict(tmp_path):
+    with set_directory(tmp_path):
+        m = Markata()
+        m.config["head"] = {}
+        m.config["head"]["text"] = [{"value": "one"}, {"value": "two"}]
+        post_template.configure(m)
+        assert m.config["head"]["text"] == "one\ntwo"
+
+
+def test_head_config_text_str_toml(tmp_path):
+    with set_directory(tmp_path):
+        Path("markata.toml").write_text(
+            toml.dumps({"markata": {"head": {"text": "here"}}})
+        )
+        m = Markata()
+        post_template.configure(m)
+        assert m.config["head"]["text"] == "here"
+
+
+def test_head_config_text_list_toml(tmp_path):
+    with set_directory(tmp_path):
+        Path("markata.toml").write_text(
+            toml.dumps(
+                {"markata": {"head": {"text": [{"value": "one"}, {"value": "two"}]}}}
+            )
+        )
+        m = Markata()
+        post_template.configure(m)
+        assert m.config["head"]["text"] == "one\ntwo"


### PR DESCRIPTION
Configurable post head

## Implements `markata.plugins.post_template.configure`.

Massages the configuration limitations of toml to allow a little bit easier
experience to the end user making configurations while allowing an simpler
jinja template.

Adding this snippet to your post template will allow users to use the same
configuration as the default template.

``` html
{{ config.get('head', {}).pop('text') if 'text' in config.get('head',{}).keys() }}{% for tag, meta in config.get('head', {}).items() %}{% for _meta in meta %}
<{{ tag }} {% for attr, value in _meta.items() %}{{ attr }}="{{ value }}"{% endfor %}/> {% endfor %}{% endfor %}
```

Here is an example config that adds

``` toml
[[markata.head.text]]
value = """
<script>
    console.log('hello world')
</script>
"""

[[markata.head.text]]
value="""
html  {
    font-family: "Space Mono", monospace;
    background: var(--color-bg);
    color: var(--color-text);
}
"""

[[markata.head.meta]]
name = "og:type"
property = "og:type"
content = "article"

[[markata.head.meta]]
name = "og:author"
property = "og:author"
content = "Waylon Walker"
```
