### PR TITLE
create teardown lifecycle method

### DIFF
--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -355,6 +355,9 @@ class Markata:
         )
         return articles
 
+    def run_one_lifecycle(self, lifecycle: LifeCycle = None) -> Markata:
+        getattr(self._pm.hook, lifecycle)(markata=self)
+
     def run(self, lifecycle: LifeCycle = None) -> Markata:
         if lifecycle is None:
             lifecycle = getattr(LifeCycle, max(LifeCycle._member_map_))

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -355,8 +355,10 @@ class Markata:
         )
         return articles
 
-    def run_one_lifecycle(self, lifecycle: LifeCycle = None) -> Markata:
-        getattr(self._pm.hook, lifecycle)(markata=self)
+    def teardown(self) -> Markata:
+        """give special access to the teardown lifecycle method"""
+        self._pm.hook.teardown(markata=self)
+        return self
 
     def run(self, lifecycle: LifeCycle = None) -> Markata:
         if lifecycle is None:

--- a/markata/lifecycle.py
+++ b/markata/lifecycle.py
@@ -37,6 +37,7 @@ class LifeCycle(Enum):
     render = auto()
     post_render = auto()
     save = auto()
+    error = auto()
 
     def __lt__(self, other: object) -> bool:
         """

--- a/markata/lifecycle.py
+++ b/markata/lifecycle.py
@@ -37,7 +37,7 @@ class LifeCycle(Enum):
     render = auto()
     post_render = auto()
     save = auto()
-    error = auto()
+    teardown = auto()
 
     def __lt__(self, other: object) -> bool:
         """


### PR DESCRIPTION
The following error is due to pyinstrument not being able to shut down properly.  The pyinstrument plugin needs  way to teardown before exit.

![](https://screenshots.waylonwalker.com/markata-pyinstrument-error.webp)