### PR TITLE
simple but not complete fix to #117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Feat: Automatically call teardown without needing to remember it before raise 0.6.0.dev6 #113
 * Fix: only stop the profiler if it is running 0.6.0.dev7 #114
 * Fix: map was giving inconsistent results 0.6.0.dev8 #116
+* Fix: tui continuously rebuilds if an input file exists in a parent directory
+  to the output directory 0.6.0.dev9 #118
 
 ## 0.5.2
 

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -304,7 +304,11 @@ class Markata:
 
     @property
     def content_dir_hash(self) -> str:
-        hashes = [dirhash(dir) for dir in self.content_directories]
+        hashes = [
+            dirhash(dir)
+            for dir in self.content_directories
+            if dir.absolute() != Path(".").absolute()
+        ]
         return self.make_hash(*hashes)
 
     @property


### PR DESCRIPTION
For default configuration this fixes #117, but there should be a better way to
guarantee that the output directory is not contained within the content
directory hashes.  This is a very naive approach to just remove the current
working directory, assuming the output is there.
