### PR TITLE
Fix typo in the link to the gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ day.
 
 Markata has a project gallery to show off sites built with markata.  Please
 [submit](https://github.com/WaylonWalker/markata/issues/78) yours, and check
-out the [project-gallery](http://markta.dev/project-gallery/) for inspiration.
+out the [project-gallery](http://markata.dev/project-gallery/) for inspiration.
 


### PR DESCRIPTION
The gallery link at the bottom of the README doesn't work due to a typo in the domain name. This corrects that.