### PR TITLE
fast

### DIFF
--- a/markata.toml
+++ b/markata.toml
@@ -7,6 +7,8 @@
 #
 #                                                  markata.dev
 
+[markata.fast]
+default_cache_expire = 1209600
 [markata.nav]
 'markata'='/'
 'GitHub'='https://github.com/WaylonWalker/markata'

--- a/markata/__init__.py
+++ b/markata/__init__.py
@@ -84,6 +84,7 @@ DEFAULT_HOOKS = [
     "markata.plugins.tui",
     "markata.plugins.setup_logging",
     "markata.plugins.redirects",
+    "markata.plugins.fast",
 ]
 
 DEFUALT_CONFIG = {

--- a/markata/plugins/base_cli.py
+++ b/markata/plugins/base_cli.py
@@ -286,6 +286,8 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
         include_empty: bool = False,
         reverse: bool = False,
         use_pager: bool = typer.Option(True, "--pager", "--no-pager"),
+        fast: bool = typer.Option(False, "--fast", "--no-fast"),
+        profile: bool = typer.Option(False, "--profile", "--no-profile"),
     ) -> None:
         """
         Provides a way run markatas, map, filter, and sort from the
@@ -452,6 +454,11 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
         `markata list` I would love to accept a PR to add it to the
         examples here.
         """
+
+        if fast:
+            articles = markata.cache.get("articles")
+            if articles is not None:
+                markata.articles = articles
 
         markata.console.quiet = True
 

--- a/markata/plugins/base_cli.py
+++ b/markata/plugins/base_cli.py
@@ -88,6 +88,7 @@ import warnings
 
 from rich import print as rich_print
 import typer
+from rich import print as rich_print
 
 from markata.hookspec import hook_impl
 
@@ -213,6 +214,7 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
             "--pdb",
         ),
         profile: bool = True,
+        clean: bool = typer.Option(False, "--clean/--no-clean", "-c"),
     ) -> None:
         """
         Markata's primary way of building your site for production.
@@ -256,11 +258,15 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
         ```
         """
 
+        if clean:
+            _clean(markata=markata, quiet=quiet, dry_run=False)
+
         if pretty:
             make_pretty()
 
         if quiet:
             markata.console.quiet = True
+
 
         if verbose:
             markata.console.print("console options:", markata.console.options)
@@ -288,6 +294,7 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
         use_pager: bool = typer.Option(True, "--pager", "--no-pager"),
         fast: bool = typer.Option(False, "--fast", "--no-fast"),
         profile: bool = typer.Option(False, "--profile", "--no-profile"),
+        clean: bool = typer.Option(False, "--clean", "--no-clean"),
     ) -> None:
         """
         Provides a way run markatas, map, filter, and sort from the
@@ -454,6 +461,9 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
         `markata list` I would love to accept a PR to add it to the
         examples here.
         """
+
+        if clean:
+            _clean(markata=markata, quiet=quiet, dry_run=False)
 
         if fast:
             articles = markata.cache.get("articles")

--- a/markata/plugins/base_cli.py
+++ b/markata/plugins/base_cli.py
@@ -267,7 +267,6 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
         if quiet:
             markata.console.quiet = True
 
-
         if verbose:
             markata.console.print("console options:", markata.console.options)
 
@@ -469,6 +468,7 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
             articles = markata.cache.get("articles")
             if articles is not None:
                 markata.articles = articles
+                markata.going_fast = True
 
         markata.console.quiet = True
 

--- a/markata/plugins/base_cli.py
+++ b/markata/plugins/base_cli.py
@@ -88,9 +88,11 @@ import warnings
 
 from rich import print as rich_print
 import typer
-from rich import print as rich_print
 
 from markata.hookspec import hook_impl
+
+# from rich import print as rich_print
+
 
 if TYPE_CHECKING:
     from markata import Markata
@@ -294,6 +296,7 @@ def cli(app: typer.Typer, markata: "Markata") -> None:
         fast: bool = typer.Option(False, "--fast", "--no-fast"),
         profile: bool = typer.Option(False, "--profile", "--no-profile"),
         clean: bool = typer.Option(False, "--clean", "--no-clean"),
+        quiet: bool = typer.Option(False, "--quiet", "-q"),
     ) -> None:
         """
         Provides a way run markatas, map, filter, and sort from the

--- a/markata/plugins/fast.py
+++ b/markata/plugins/fast.py
@@ -33,6 +33,13 @@ def keys_on_file(post: frontmatter.Post) -> Dict[str, str]:
 
 @hook_impl
 def teardown(markata) -> None:
-    with markata.cache as cache:
-        articles = copy.deepcopy(markata.articles)
-        cache.add("articles", articles)
+    if getattr(markata, "going_fast", False):
+        markata.console.log(f"going_fast")
+    else:
+        with markata.cache as cache:
+            markata.console.log(f"not going_fast")
+            articles = copy.deepcopy(markata.articles)
+            expire = markata.config.get("fast", markata.config).get(
+                "default_cache_expire", 1209600
+            )
+            cache.add("articles", articles, expire=expire)

--- a/markata/plugins/fast.py
+++ b/markata/plugins/fast.py
@@ -43,13 +43,9 @@ def keys_on_file(post: frontmatter.Post) -> Dict[str, str]:
 
 @hook_impl
 def teardown(markata) -> None:
-    if getattr(markata, "going_fast", False):
-        markata.console.log(f"going_fast")
-    else:
-        with markata.cache as cache:
-            markata.console.log(f"not going_fast")
-            articles = copy.deepcopy(markata.articles)
-            expire = markata.config.get("fast", markata.config).get(
-                "default_cache_expire", 1209600
-            )
-            cache.add("articles", articles, expire=expire)
+    with markata.cache as cache:
+        articles = copy.deepcopy(markata.articles)
+        expire = markata.config.get("fast", markata.config).get(
+            "default_cache_expire", 1209600
+        )
+        cache.add("articles", articles, expire=expire)

--- a/markata/plugins/fast.py
+++ b/markata/plugins/fast.py
@@ -1,5 +1,7 @@
 """
-fast
+fast is a plugin that allows markata to load fast.  It will store all articles in
+cache on exit, so when running commands like `markata list` markata only needs to
+pull from cache, and not process any files.
 
 Enable this plugin by adding it to your `markata.toml` hooks list.
 

--- a/markata/plugins/fast.py
+++ b/markata/plugins/fast.py
@@ -11,6 +11,14 @@ hooks=[
 ]
 ```
 
+## Configuration
+
+If you want a different cache expiration on the articles stored in fast you can
+configure this in your `markata.toml` configuration file.
+
+[markata.fast]
+default_cache_expire = 12
+
 """
 import copy
 from typing import Dict

--- a/markata/plugins/fast.py
+++ b/markata/plugins/fast.py
@@ -1,0 +1,38 @@
+"""
+fast
+
+Enable this plugin by adding it to your `markata.toml` hooks list.
+
+``` toml
+[markata]
+hooks=[
+  # your hooks
+  "markata.plugins.fast",
+]
+```
+
+"""
+import copy
+from typing import Dict
+
+import frontmatter
+
+from markata.hookspec import hook_impl
+
+
+def keys_on_file(post: frontmatter.Post) -> Dict[str, str]:
+    if post.get("path") is not None:
+        try:
+            return {
+                key: value
+                for key, value in frontmatter.load(post.get("path")).metadata.items()
+            }
+        except FileNotFoundError:
+            return
+
+
+@hook_impl
+def teardown(markata) -> None:
+    with markata.cache as cache:
+        articles = copy.deepcopy(markata.articles)
+        cache.add("articles", articles)


### PR DESCRIPTION
- wip fast
- implement --clean
- mark when going fast
- only store articles when the going_fast marker is not present
- document how to change the cache expiration for fast
- docstring
- add fast cache_expire
- fix flake8 issues
- make filter api match map (#133)
- remove unused Post
- fix seed-isort-config error
- Bump version: 0.6.0.dev13 → 0.6.0.dev14
- implement path_prefix (#132)
- Bump version: 0.6.0.dev14 → 0.6.0.dev15
- create plugin cli (#109)
- Bump version: 0.6.0.dev15 → 0.6.0.dev16
- use path_prefix in nav unless :// is used (#136)
- Bump version: 0.6.0.dev16 → 0.6.0.dev17
- enable wikilinks (#138)
- Bump version: 0.6.0.dev17 → 0.6.0.dev18
- give access to markata inside feed card rendering (#139)
- Bump version: 0.6.0.dev18 → 0.6.0.dev19
- add a note about changing your favicon
- linting README
- linting CHANGELOG
- implement --clean
